### PR TITLE
[채채] 4단계 자동 DI 미션 제출합니다

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,3 +79,21 @@
 
 - DSL을 활용한다.
 - 내가 만든 DI 라이브러리를 배포하고 적용한다.
+
+---
+
+## 4단계: LifeCycle
+
+### 기능 요구 사항 🛠️
+
+- CartActivity에서 사용하는 DateFormatter의 인스턴스를 매번 개발자가 관리해야 하는 문제를 해결한다.
+- 모든 의존성이 싱글 오브젝트로 만들어질 필요 없다.
+    - CartRepository는 앱 전체 LifeCycle 동안 유지되도록 구현한다.
+    - ProductRepository는 ViewModel LifeCycle 동안 유지되도록 구현한다.
+    - DateFormatter는 Activity LifeCycle 동안 유지되도록 구현한다.
+- 내가 만든 DI 라이브러리가 잘 작동하는지 테스트를 작성한다.
+
+### 선택 요구 사항 📦
+
+- DateFormatter가 Configuration Changes에도 살아남을 수 있도록 구현한다.
+- Activity, ViewModel 외에도 다양한 컴포넌트(Fragment, Service 등)별 유지될 의존성을 관리한다.

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,6 +13,7 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
+        tools:replace="android:theme"
         android:theme="@style/Theme.Shopping"
         tools:targetApi="33">
         <activity

--- a/app/src/main/java/woowacourse/shopping/di/module/DatabaseModule.kt
+++ b/app/src/main/java/woowacourse/shopping/di/module/DatabaseModule.kt
@@ -19,8 +19,18 @@ class DatabaseModule(private val context: Context) : DIModule {
 
         val cartProductDao = database.cartProductDao()
 
-        container.registerInstance(CartProductDao::class, cartProductDao, QualifierType.DATABASE)
+        container.registerComponentScopedInstance(
+            type = CartProductDao::class,
+            instance = cartProductDao,
+            qualifier = QualifierType.DATABASE,
+            owner = this
+        )
 
-        container.registerInstance(ShoppingDatabase::class, database, QualifierType.DATABASE)
+        container.registerComponentScopedInstance(
+            type = ShoppingDatabase::class,
+            instance = database,
+            qualifier = QualifierType.DATABASE,
+            owner = this
+        )
     }
 }

--- a/app/src/main/java/woowacourse/shopping/di/module/DatabaseModule.kt
+++ b/app/src/main/java/woowacourse/shopping/di/module/DatabaseModule.kt
@@ -19,18 +19,16 @@ class DatabaseModule(private val context: Context) : DIModule {
 
         val cartProductDao = database.cartProductDao()
 
-        container.registerComponentScopedInstance(
+        container.registerModuleInstance(
             type = CartProductDao::class,
             instance = cartProductDao,
             qualifier = QualifierType.DATABASE,
-            owner = this
         )
 
-        container.registerComponentScopedInstance(
+        container.registerModuleInstance(
             type = ShoppingDatabase::class,
             instance = database,
             qualifier = QualifierType.DATABASE,
-            owner = this
         )
     }
 }

--- a/app/src/main/java/woowacourse/shopping/di/module/RepositoryModule.kt
+++ b/app/src/main/java/woowacourse/shopping/di/module/RepositoryModule.kt
@@ -14,22 +14,25 @@ class RepositoryModule : DIModule {
     override fun register(container: DIContainer) {
         val cartProductDao = container.resolve(CartProductDao::class, QualifierType.DATABASE)
 
-        container.registerInstance(
-            ProductRepository::class,
-            DefaultProductRepository(),
-            QualifierType.IN_MEMORY,
+        container.registerComponentScopedInstance(
+            type = ProductRepository::class,
+            instance = DefaultProductRepository(),
+            qualifier = QualifierType.IN_MEMORY,
+            owner = this,
         )
 
-        container.registerInstance(
-            CartRepository::class,
-            DefaultCartRepository(cartProductDao),
-            QualifierType.DATABASE,
+        container.registerComponentScopedInstance(
+            type = CartRepository::class,
+            instance = DefaultCartRepository(cartProductDao),
+            qualifier = QualifierType.DATABASE,
+            owner = this,
         )
 
-        container.registerInstance(
-            CartRepository::class,
-            InMemoryCartRepository(),
-            QualifierType.IN_MEMORY,
+        container.registerComponentScopedInstance(
+            type = CartRepository::class,
+            instance = InMemoryCartRepository(),
+            qualifier = QualifierType.IN_MEMORY,
+            owner = this,
         )
     }
 }

--- a/app/src/main/java/woowacourse/shopping/di/module/RepositoryModule.kt
+++ b/app/src/main/java/woowacourse/shopping/di/module/RepositoryModule.kt
@@ -14,25 +14,22 @@ class RepositoryModule : DIModule {
     override fun register(container: DIContainer) {
         val cartProductDao = container.resolve(CartProductDao::class, QualifierType.DATABASE)
 
-        container.registerComponentScopedInstance(
+        container.registerModuleInstance(
             type = ProductRepository::class,
             instance = DefaultProductRepository(),
             qualifier = QualifierType.IN_MEMORY,
-            owner = this,
         )
 
-        container.registerComponentScopedInstance(
+        container.registerModuleInstance(
             type = CartRepository::class,
             instance = DefaultCartRepository(cartProductDao),
             qualifier = QualifierType.DATABASE,
-            owner = this,
         )
 
-        container.registerComponentScopedInstance(
+        container.registerModuleInstance(
             type = CartRepository::class,
             instance = InMemoryCartRepository(),
             qualifier = QualifierType.IN_MEMORY,
-            owner = this,
         )
     }
 }

--- a/app/src/main/java/woowacourse/shopping/domain/CartRepository.kt
+++ b/app/src/main/java/woowacourse/shopping/domain/CartRepository.kt
@@ -1,8 +1,10 @@
 package woowacourse.shopping.domain
 
+import com.zzang.di.annotation.lifecycle.ApplicationComponent
 import woowacourse.shopping.model.CartProduct
 import woowacourse.shopping.model.Product
 
+@ApplicationComponent
 interface CartRepository {
     suspend fun addCartProduct(product: Product)
 

--- a/app/src/main/java/woowacourse/shopping/domain/ProductRepository.kt
+++ b/app/src/main/java/woowacourse/shopping/domain/ProductRepository.kt
@@ -1,7 +1,9 @@
 package woowacourse.shopping.domain
 
+import com.zzang.di.annotation.lifecycle.ViewModelComponent
 import woowacourse.shopping.model.Product
 
+@ViewModelComponent
 interface ProductRepository {
     fun getAllProducts(): List<Product>
 }

--- a/app/src/main/java/woowacourse/shopping/ui/MainActivity.kt
+++ b/app/src/main/java/woowacourse/shopping/ui/MainActivity.kt
@@ -5,6 +5,7 @@ import android.os.Bundle
 import android.view.Menu
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
+import com.zzang.di.DIContainer
 import com.zzang.di.provideViewModel
 import woowacourse.shopping.R
 import woowacourse.shopping.databinding.ActivityMainBinding
@@ -67,5 +68,10 @@ class MainActivity : AppCompatActivity() {
 
     private fun navigateToCart() {
         startActivity(Intent(this, CartActivity::class.java))
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        DIContainer.clearActivityScopedInstances(this)
     }
 }

--- a/app/src/main/java/woowacourse/shopping/ui/MainActivity.kt
+++ b/app/src/main/java/woowacourse/shopping/ui/MainActivity.kt
@@ -4,14 +4,13 @@ import android.content.Intent
 import android.os.Bundle
 import android.view.Menu
 import android.widget.Toast
-import androidx.appcompat.app.AppCompatActivity
-import com.zzang.di.DIContainer
+import com.zzang.di.base.DIActivity
 import com.zzang.di.provideViewModel
 import woowacourse.shopping.R
 import woowacourse.shopping.databinding.ActivityMainBinding
 import woowacourse.shopping.ui.cart.CartActivity
 
-class MainActivity : AppCompatActivity() {
+class MainActivity : DIActivity() {
     private val binding by lazy { ActivityMainBinding.inflate(layoutInflater) }
 
     private val viewModel: MainViewModel by provideViewModel()
@@ -68,10 +67,5 @@ class MainActivity : AppCompatActivity() {
 
     private fun navigateToCart() {
         startActivity(Intent(this, CartActivity::class.java))
-    }
-
-    override fun onDestroy() {
-        super.onDestroy()
-        DIContainer.clearActivityScopedInstances(this)
     }
 }

--- a/app/src/main/java/woowacourse/shopping/ui/MainViewModel.kt
+++ b/app/src/main/java/woowacourse/shopping/ui/MainViewModel.kt
@@ -2,17 +2,16 @@ package woowacourse.shopping.ui
 
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
-import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.zzang.di.DIContainer
 import com.zzang.di.annotation.Inject
 import com.zzang.di.annotation.QualifierType
+import com.zzang.di.base.DIViewModel
 import kotlinx.coroutines.launch
 import woowacourse.shopping.domain.CartRepository
 import woowacourse.shopping.domain.ProductRepository
 import woowacourse.shopping.model.Product
 
-class MainViewModel : ViewModel() {
+class MainViewModel : DIViewModel() {
     @Inject(qualifier = QualifierType.IN_MEMORY)
     lateinit var productRepository: ProductRepository
 
@@ -34,10 +33,5 @@ class MainViewModel : ViewModel() {
 
     fun getAllProducts() {
         _products.value = productRepository.getAllProducts()
-    }
-
-    override fun onCleared() {
-        super.onCleared()
-        DIContainer.clearViewModelScopedInstances(this)
     }
 }

--- a/app/src/main/java/woowacourse/shopping/ui/MainViewModel.kt
+++ b/app/src/main/java/woowacourse/shopping/ui/MainViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.zzang.di.DIContainer
 import com.zzang.di.annotation.Inject
 import com.zzang.di.annotation.QualifierType
 import kotlinx.coroutines.launch
@@ -33,5 +34,10 @@ class MainViewModel : ViewModel() {
 
     fun getAllProducts() {
         _products.value = productRepository.getAllProducts()
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        DIContainer.clearViewModelScopedInstances(this)
     }
 }

--- a/app/src/main/java/woowacourse/shopping/ui/cart/CartActivity.kt
+++ b/app/src/main/java/woowacourse/shopping/ui/cart/CartActivity.kt
@@ -2,15 +2,13 @@ package woowacourse.shopping.ui.cart
 
 import android.os.Bundle
 import android.widget.Toast
-import androidx.appcompat.app.AppCompatActivity
-import com.zzang.di.DIContainer.clearActivityScopedInstances
-import com.zzang.di.DependencyInjector
 import com.zzang.di.annotation.Inject
+import com.zzang.di.base.DIActivity
 import com.zzang.di.provideViewModel
 import woowacourse.shopping.R
 import woowacourse.shopping.databinding.ActivityCartBinding
 
-class CartActivity : AppCompatActivity() {
+class CartActivity : DIActivity() {
     private val binding by lazy { ActivityCartBinding.inflate(layoutInflater) }
 
     private val viewModel: CartViewModel by provideViewModel()
@@ -22,7 +20,6 @@ class CartActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        DependencyInjector.injectDependencies(this, this)
         setupBinding()
         setupToolbar()
         setupView()
@@ -70,10 +67,5 @@ class CartActivity : AppCompatActivity() {
             if (!it) return@observe
             Toast.makeText(this, getString(R.string.cart_deleted), Toast.LENGTH_SHORT).show()
         }
-    }
-
-    override fun onDestroy() {
-        super.onDestroy()
-        clearActivityScopedInstances(this)
     }
 }

--- a/app/src/main/java/woowacourse/shopping/ui/cart/CartActivity.kt
+++ b/app/src/main/java/woowacourse/shopping/ui/cart/CartActivity.kt
@@ -22,7 +22,7 @@ class CartActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        DependencyInjector.injectDependencies(this,this)
+        DependencyInjector.injectDependencies(this, this)
         setupBinding()
         setupToolbar()
         setupView()

--- a/app/src/main/java/woowacourse/shopping/ui/cart/CartActivity.kt
+++ b/app/src/main/java/woowacourse/shopping/ui/cart/CartActivity.kt
@@ -3,6 +3,9 @@ package woowacourse.shopping.ui.cart
 import android.os.Bundle
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
+import com.zzang.di.DIContainer.clearActivityScopedInstances
+import com.zzang.di.DependencyInjector
+import com.zzang.di.annotation.Inject
 import com.zzang.di.provideViewModel
 import woowacourse.shopping.R
 import woowacourse.shopping.databinding.ActivityCartBinding
@@ -12,13 +15,14 @@ class CartActivity : AppCompatActivity() {
 
     private val viewModel: CartViewModel by provideViewModel()
 
+    @Inject
     private lateinit var dateFormatter: DateFormatter
     private lateinit var adapter: CartProductAdapter
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        setupDateFormatter()
+        DependencyInjector.injectDependencies(this,this)
         setupBinding()
         setupToolbar()
         setupView()
@@ -28,10 +32,6 @@ class CartActivity : AppCompatActivity() {
     override fun onSupportNavigateUp(): Boolean {
         finish()
         return true
-    }
-
-    private fun setupDateFormatter() {
-        dateFormatter = DateFormatter(this)
     }
 
     private fun setupToolbar() {
@@ -70,5 +70,10 @@ class CartActivity : AppCompatActivity() {
             if (!it) return@observe
             Toast.makeText(this, getString(R.string.cart_deleted), Toast.LENGTH_SHORT).show()
         }
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        clearActivityScopedInstances(this)
     }
 }

--- a/app/src/main/java/woowacourse/shopping/ui/cart/CartViewModel.kt
+++ b/app/src/main/java/woowacourse/shopping/ui/cart/CartViewModel.kt
@@ -2,17 +2,15 @@ package woowacourse.shopping.ui.cart
 
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
-import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.zzang.di.DIContainer
-import com.zzang.di.DependencyInjector
 import com.zzang.di.annotation.Inject
 import com.zzang.di.annotation.QualifierType
+import com.zzang.di.base.DIViewModel
 import kotlinx.coroutines.launch
 import woowacourse.shopping.domain.CartRepository
 import woowacourse.shopping.model.CartProduct
 
-class CartViewModel : ViewModel() {
+class CartViewModel : DIViewModel() {
     @Inject(qualifier = QualifierType.DATABASE)
     lateinit var cartRepository: CartRepository
 
@@ -21,10 +19,6 @@ class CartViewModel : ViewModel() {
 
     private val _onCartProductDeleted: MutableLiveData<Boolean> = MutableLiveData(false)
     val onCartProductDeleted: LiveData<Boolean> get() = _onCartProductDeleted
-
-    init {
-        DependencyInjector.injectDependencies(this, this)
-    }
 
     fun getAllCartProducts() {
         viewModelScope.launch {
@@ -42,10 +36,5 @@ class CartViewModel : ViewModel() {
                 _onCartProductDeleted.value = false
             }
         }
-    }
-
-    override fun onCleared() {
-        super.onCleared()
-        DIContainer.clearViewModelScopedInstances(this)
     }
 }

--- a/app/src/main/java/woowacourse/shopping/ui/cart/CartViewModel.kt
+++ b/app/src/main/java/woowacourse/shopping/ui/cart/CartViewModel.kt
@@ -4,6 +4,8 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.zzang.di.DIContainer
+import com.zzang.di.DependencyInjector
 import com.zzang.di.annotation.Inject
 import com.zzang.di.annotation.QualifierType
 import kotlinx.coroutines.launch
@@ -19,6 +21,10 @@ class CartViewModel : ViewModel() {
 
     private val _onCartProductDeleted: MutableLiveData<Boolean> = MutableLiveData(false)
     val onCartProductDeleted: LiveData<Boolean> get() = _onCartProductDeleted
+
+    init {
+        DependencyInjector.injectDependencies(this, this)
+    }
 
     fun getAllCartProducts() {
         viewModelScope.launch {
@@ -36,5 +42,10 @@ class CartViewModel : ViewModel() {
                 _onCartProductDeleted.value = false
             }
         }
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        DIContainer.clearViewModelScopedInstances(this)
     }
 }

--- a/app/src/main/java/woowacourse/shopping/ui/cart/DateFormatter.kt
+++ b/app/src/main/java/woowacourse/shopping/ui/cart/DateFormatter.kt
@@ -1,11 +1,13 @@
 package woowacourse.shopping.ui.cart
 
 import android.content.Context
+import com.zzang.di.annotation.lifecycle.ActivityComponent
 import woowacourse.shopping.R
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
 
+@ActivityComponent
 class DateFormatter(context: Context) {
     private val formatter =
         SimpleDateFormat(

--- a/di/build.gradle.kts
+++ b/di/build.gradle.kts
@@ -64,5 +64,5 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-reflect:1.9.23")
     // Robolectric
     testImplementation("org.robolectric:robolectric:4.13")
-    testImplementation ("androidx.test:core:1.4.0")
+    testImplementation("androidx.test:core:1.4.0")
 }

--- a/di/build.gradle.kts
+++ b/di/build.gradle.kts
@@ -15,6 +15,12 @@ android {
         consumerProguardFiles("consumer-rules.pro")
     }
 
+    sourceSets {
+        getByName("test") {
+            manifest.srcFile("src/test/AndroidManifest.xml")
+        }
+    }
+
     buildTypes {
         release {
             isMinifyEnabled = false
@@ -31,6 +37,10 @@ android {
     kotlinOptions {
         jvmTarget = "1.8"
     }
+
+    buildFeatures {
+        dataBinding = true
+    }
 }
 
 dependencies {
@@ -42,6 +52,8 @@ dependencies {
     implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.8.4")
     implementation("androidx.lifecycle:lifecycle-extensions:2.2.0")
     implementation("javax.inject:javax.inject:1")
+    implementation("androidx.navigation:navigation-fragment-ktx:2.8.1")
+    implementation("androidx.navigation:navigation-ui-ktx:2.8.1")
     testImplementation("junit:junit:4.13.2")
     testImplementation("com.google.truth:truth:1.1.3")
     testImplementation("androidx.arch.core:core-testing:2.2.0")
@@ -52,4 +64,5 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-reflect:1.9.23")
     // Robolectric
     testImplementation("org.robolectric:robolectric:4.13")
+    testImplementation ("androidx.test:core:1.4.0")
 }

--- a/di/build.gradle.kts
+++ b/di/build.gradle.kts
@@ -15,12 +15,6 @@ android {
         consumerProguardFiles("consumer-rules.pro")
     }
 
-    sourceSets {
-        getByName("test") {
-            manifest.srcFile("src/test/AndroidManifest.xml")
-        }
-    }
-
     buildTypes {
         release {
             isMinifyEnabled = false

--- a/di/src/main/AndroidManifest.xml
+++ b/di/src/main/AndroidManifest.xml
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
-
+    <application
+        android:theme="@style/Theme.AppCompat">
+    </application>
 </manifest>

--- a/di/src/main/java/com/zzang/di/DIContainer.kt
+++ b/di/src/main/java/com/zzang/di/DIContainer.kt
@@ -1,13 +1,22 @@
 package com.zzang.di
 
+import android.content.Context
+import android.util.Log
+import androidx.activity.ComponentActivity
+import androidx.lifecycle.ViewModel
 import com.zzang.di.annotation.QualifierType
+import com.zzang.di.annotation.lifecycle.ActivityComponent
+import com.zzang.di.annotation.lifecycle.ApplicationComponent
+import com.zzang.di.annotation.lifecycle.ViewModelComponent
 import com.zzang.di.module.DIModule
 import kotlin.reflect.KClass
+import kotlin.reflect.full.findAnnotation
 import kotlin.reflect.full.primaryConstructor
 
 object DIContainer {
-    private val singletonInstances = mutableMapOf<String, Any>()
-    private val interfaceMappings = mutableMapOf<String, KClass<*>>()
+    private val applicationScopedInstances = mutableMapOf<String, Any>()
+    private val activityScopedInstances = mutableMapOf<ComponentActivity, MutableMap<String, Any>>()
+    private val viewModelScopedInstances = mutableMapOf<ViewModel, MutableMap<String, Any>>()
 
     fun loadModule(module: DIModule) {
         module.register(this)
@@ -15,42 +24,116 @@ object DIContainer {
 
     private fun buildKey(
         type: KClass<*>,
-        qualifier: QualifierType,
+        qualifier: QualifierType? = null,
     ): String {
-        return "${type.qualifiedName}_${qualifier.name}"
+        return "${type.qualifiedName}_${qualifier?.name}"
     }
 
-    fun <T : Any> registerInstance(
+    fun <T : Any> registerComponentScopedInstance(
+        type: KClass<T>,
+        instance: T,
+        qualifier: QualifierType? = null,
+        owner: Any? = null,
+    ) {
+        Log.d("DIContainer 어노테이션", "${type.simpleName}=${type.annotations}$owner")
+        when {
+            type.findAnnotation<ApplicationComponent>() != null -> {
+                Log.d("DIContainer", "registerSingletonInstance: ${type.simpleName}")
+                registerSingletonInstance(type, instance, qualifier)
+            }
+
+            type.findAnnotation<ActivityComponent>() != null && owner is ComponentActivity -> {
+                Log.d("DIContainer", "registerActivityScopedInstance: ${type.simpleName}")
+                registerActivityScopedInstance(owner, type, instance)
+            }
+
+            type.findAnnotation<ViewModelComponent>() != null && owner is ViewModel -> {
+                Log.d("DIContainer", "registerViewModelScopedInstance: ${type.simpleName}")
+                registerViewModelScopedInstance(owner, type, instance)
+            }
+
+            else -> {
+                registerSingletonInstance(type, instance, qualifier)
+            }
+        }
+    }
+
+    fun <T : Any> registerSingletonInstance(
         interfaceClass: KClass<T>,
         instance: T,
-        qualifier: QualifierType = QualifierType.DATABASE,
+        qualifier: QualifierType? = null,
     ) {
         val key = buildKey(interfaceClass, qualifier)
-        singletonInstances[key] = instance
+        applicationScopedInstances[key] = instance
+    }
+
+    private fun <T : Any> registerActivityScopedInstance(
+        activity: ComponentActivity,
+        type: KClass<T>,
+        instance: T,
+    ) {
+        val key = buildKey(type)
+        activityScopedInstances.getOrPut(activity) { mutableMapOf() }[key] = instance
+    }
+
+    private fun <T : Any> registerViewModelScopedInstance(
+        viewModel: ViewModel,
+        type: KClass<T>,
+        instance: T,
+    ) {
+        val key = buildKey(type)
+        viewModelScopedInstances.getOrPut(viewModel) { mutableMapOf() }[key] = instance
     }
 
     @Suppress("UNCHECKED_CAST")
     fun <T : Any> resolve(
         type: KClass<T>,
-        qualifier: QualifierType = QualifierType.DATABASE,
+        qualifier: QualifierType? = null,
+        owner: Any? = null,
     ): T {
         val key = buildKey(type, qualifier)
-        singletonInstances[key]?.let { return it as T }
+        applicationScopedInstances[key]?.let { return it as T }
 
-        val implementationType = interfaceMappings[key] ?: type
+        if (type == Context::class) {
+            return owner as T
+        }
 
-        val constructor =
-            implementationType.primaryConstructor
-                ?: throw IllegalArgumentException("${implementationType.simpleName} 클래스의 인스턴스를 생성할 수 없습니다. 생성자가 없습니다.")
+        if (owner is ComponentActivity) {
+            registerActivityScopedInstance(owner, type, createInstance(type, qualifier, owner))
+        }
 
-        val parameters =
-            constructor.parameters.map { parameter ->
-                val parameterType = parameter.type.classifier as KClass<*>
-                resolve(parameterType)
-            }
+        if (owner is ViewModel) {
+            registerViewModelScopedInstance(owner, type, createInstance(type, qualifier, owner))
+        }
 
-        val instance = constructor.call(*parameters.toTypedArray()) as T
-        registerInstance(type, instance, qualifier)
-        return instance
+        return createInstance(type, qualifier, owner)
+    }
+
+    private fun <T : Any> createInstance(
+        type: KClass<T>,
+        qualifier: QualifierType? = null,
+        owner: Any? = null,
+    ): T {
+        val constructor = type.primaryConstructor
+        if (constructor != null) {
+            val parameters =
+                constructor.parameters.map { parameter ->
+                    val parameterType = parameter.type.classifier as KClass<*>
+                    resolve(parameterType, qualifier = qualifier, owner = owner)
+                }
+            return constructor.call(*parameters.toTypedArray())
+        }
+
+        throw IllegalArgumentException("${type.simpleName} 클래스에 사용할 수 있는 생성자가 없습니다. 이미 등록된 인스턴스를 사용하십시오.")
+    }
+
+    fun clearActivityScopedInstances(activity: ComponentActivity) {
+        Log.d("DIContainer", "clearActivityScopedInstances: ${activityScopedInstances.values}")
+        activityScopedInstances.remove(activity)
+    }
+
+    fun clearViewModelScopedInstances(viewModel: ViewModel) {
+        Log.d("DIContainer", "clearViewModelScopedInstances: ${viewModelScopedInstances.values}")
+        viewModelScopedInstances.remove(viewModel)
     }
 }

--- a/di/src/main/java/com/zzang/di/DIContainer.kt
+++ b/di/src/main/java/com/zzang/di/DIContainer.kt
@@ -137,4 +137,15 @@ object DIContainer {
     fun clearViewModelScopedInstances(viewModel: ViewModel) {
         viewModelScopedInstances.remove(viewModel)
     }
+
+    fun activityScopedInstanceSize(): Int {
+        return activityScopedInstances.size
+    }
+
+    fun clearAll() {
+        moduleInstances.clear()
+        applicationScopedInstances.clear()
+        activityScopedInstances.clear()
+        viewModelScopedInstances.clear()
+    }
 }

--- a/di/src/main/java/com/zzang/di/DIContainer.kt
+++ b/di/src/main/java/com/zzang/di/DIContainer.kt
@@ -1,7 +1,6 @@
 package com.zzang.di
 
 import android.content.Context
-import android.util.Log
 import androidx.activity.ComponentActivity
 import androidx.lifecycle.ViewModel
 import com.zzang.di.annotation.QualifierType
@@ -14,6 +13,7 @@ import kotlin.reflect.full.findAnnotation
 import kotlin.reflect.full.primaryConstructor
 
 object DIContainer {
+    private val moduleInstances = mutableMapOf<String, Any>()
     private val applicationScopedInstances = mutableMapOf<String, Any>()
     private val activityScopedInstances = mutableMapOf<ComponentActivity, MutableMap<String, Any>>()
     private val viewModelScopedInstances = mutableMapOf<ViewModel, MutableMap<String, Any>>()
@@ -29,26 +29,31 @@ object DIContainer {
         return "${type.qualifiedName}_${qualifier?.name}"
     }
 
-    fun <T : Any> registerComponentScopedInstance(
+    fun <T : Any> registerModuleInstance(
+        type: KClass<T>,
+        instance: T,
+        qualifier: QualifierType? = null,
+    ) {
+        val key = buildKey(type, qualifier)
+        moduleInstances[key] = instance
+    }
+
+    private fun <T : Any> registerComponentScopedInstance(
         type: KClass<T>,
         instance: T,
         qualifier: QualifierType? = null,
         owner: Any? = null,
     ) {
-        Log.d("DIContainer 어노테이션", "${type.simpleName}=${type.annotations}$owner")
         when {
             type.findAnnotation<ApplicationComponent>() != null -> {
-                Log.d("DIContainer", "registerSingletonInstance: ${type.simpleName}")
                 registerSingletonInstance(type, instance, qualifier)
             }
 
             type.findAnnotation<ActivityComponent>() != null && owner is ComponentActivity -> {
-                Log.d("DIContainer", "registerActivityScopedInstance: ${type.simpleName}")
                 registerActivityScopedInstance(owner, type, instance)
             }
 
             type.findAnnotation<ViewModelComponent>() != null && owner is ViewModel -> {
-                Log.d("DIContainer", "registerViewModelScopedInstance: ${type.simpleName}")
                 registerViewModelScopedInstance(owner, type, instance)
             }
 
@@ -92,21 +97,19 @@ object DIContainer {
         owner: Any? = null,
     ): T {
         val key = buildKey(type, qualifier)
-        applicationScopedInstances[key]?.let { return it as T }
 
         if (type == Context::class) {
             return owner as T
         }
 
-        if (owner is ComponentActivity) {
-            registerActivityScopedInstance(owner, type, createInstance(type, qualifier, owner))
+        moduleInstances[key]?.let { instance ->
+            registerComponentScopedInstance(type, instance as T, qualifier, owner)
+            return instance
         }
 
-        if (owner is ViewModel) {
-            registerViewModelScopedInstance(owner, type, createInstance(type, qualifier, owner))
+        return createInstance(type, qualifier, owner).also {
+            registerComponentScopedInstance(type, it, qualifier, owner)
         }
-
-        return createInstance(type, qualifier, owner)
     }
 
     private fun <T : Any> createInstance(
@@ -128,12 +131,10 @@ object DIContainer {
     }
 
     fun clearActivityScopedInstances(activity: ComponentActivity) {
-        Log.d("DIContainer", "clearActivityScopedInstances: ${activityScopedInstances.values}")
         activityScopedInstances.remove(activity)
     }
 
     fun clearViewModelScopedInstances(viewModel: ViewModel) {
-        Log.d("DIContainer", "clearViewModelScopedInstances: ${viewModelScopedInstances.values}")
         viewModelScopedInstances.remove(viewModel)
     }
 }

--- a/di/src/main/java/com/zzang/di/DIContainer.kt
+++ b/di/src/main/java/com/zzang/di/DIContainer.kt
@@ -13,20 +13,20 @@ import kotlin.reflect.full.findAnnotation
 import kotlin.reflect.full.primaryConstructor
 
 object DIContainer {
-    private val moduleInstances = mutableMapOf<String, Any>()
-    private val applicationScopedInstances = mutableMapOf<String, Any>()
-    private val activityScopedInstances = mutableMapOf<ComponentActivity, MutableMap<String, Any>>()
-    private val viewModelScopedInstances = mutableMapOf<ViewModel, MutableMap<String, Any>>()
+    private val moduleInstances = mutableMapOf<Dependency, Any>()
+    private val applicationScopedInstances = mutableMapOf<Dependency, Any>()
+    private val activityScopedInstances = mutableMapOf<ComponentActivity, MutableMap<Dependency, Any>>()
+    private val viewModelScopedInstances = mutableMapOf<ViewModel, MutableMap<Dependency, Any>>()
 
     fun loadModule(module: DIModule) {
         module.register(this)
     }
 
-    private fun buildKey(
+    private fun buildDependency(
         type: KClass<*>,
         qualifier: QualifierType? = null,
-    ): String {
-        return "${type.qualifiedName}_${qualifier?.name}"
+    ): Dependency {
+        return Dependency(type, qualifier)
     }
 
     fun <T : Any> registerModuleInstance(
@@ -34,7 +34,7 @@ object DIContainer {
         instance: T,
         qualifier: QualifierType? = null,
     ) {
-        val key = buildKey(type, qualifier)
+        val key = buildDependency(type, qualifier)
         moduleInstances[key] = instance
     }
 
@@ -68,7 +68,7 @@ object DIContainer {
         instance: T,
         qualifier: QualifierType? = null,
     ) {
-        val key = buildKey(interfaceClass, qualifier)
+        val key = buildDependency(interfaceClass, qualifier)
         applicationScopedInstances[key] = instance
     }
 
@@ -77,7 +77,7 @@ object DIContainer {
         type: KClass<T>,
         instance: T,
     ) {
-        val key = buildKey(type)
+        val key = buildDependency(type)
         activityScopedInstances.getOrPut(activity) { mutableMapOf() }[key] = instance
     }
 
@@ -86,7 +86,7 @@ object DIContainer {
         type: KClass<T>,
         instance: T,
     ) {
-        val key = buildKey(type)
+        val key = buildDependency(type)
         viewModelScopedInstances.getOrPut(viewModel) { mutableMapOf() }[key] = instance
     }
 
@@ -96,7 +96,7 @@ object DIContainer {
         qualifier: QualifierType? = null,
         owner: Any? = null,
     ): T {
-        val key = buildKey(type, qualifier)
+        val key = buildDependency(type, qualifier)
 
         if (type == Context::class) {
             return owner as T

--- a/di/src/main/java/com/zzang/di/DIContainer.kt
+++ b/di/src/main/java/com/zzang/di/DIContainer.kt
@@ -35,7 +35,9 @@ object DIContainer {
         qualifier: QualifierType? = null,
     ) {
         val key = buildDependency(type, qualifier)
-        moduleInstances[key] = instance
+        if(!moduleInstances.containsKey(key)) {
+            moduleInstances[key] = instance
+        }
     }
 
     private fun <T : Any> registerComponentScopedInstance(

--- a/di/src/main/java/com/zzang/di/DIContainer.kt
+++ b/di/src/main/java/com/zzang/di/DIContainer.kt
@@ -142,6 +142,10 @@ object DIContainer {
         return activityScopedInstances.size
     }
 
+    fun viewModelScopedInstanceSize(): Int {
+        return viewModelScopedInstances.size
+    }
+
     fun clearAll() {
         moduleInstances.clear()
         applicationScopedInstances.clear()

--- a/di/src/main/java/com/zzang/di/DIContainer.kt
+++ b/di/src/main/java/com/zzang/di/DIContainer.kt
@@ -63,7 +63,7 @@ object DIContainer {
         }
     }
 
-    fun <T : Any> registerSingletonInstance(
+    private fun <T : Any> registerSingletonInstance(
         interfaceClass: KClass<T>,
         instance: T,
         qualifier: QualifierType? = null,

--- a/di/src/main/java/com/zzang/di/Dependency.kt
+++ b/di/src/main/java/com/zzang/di/Dependency.kt
@@ -1,0 +1,6 @@
+package com.zzang.di
+
+import com.zzang.di.annotation.QualifierType
+import kotlin.reflect.KClass
+
+data class Dependency(val type: KClass<*>, val qualifierType: QualifierType?)

--- a/di/src/main/java/com/zzang/di/ViewModelFactory.kt
+++ b/di/src/main/java/com/zzang/di/ViewModelFactory.kt
@@ -6,7 +6,7 @@ import androidx.lifecycle.ViewModelProvider
 class ViewModelFactory : ViewModelProvider.Factory {
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
         val viewModel = DependencyInjector.inject(modelClass.kotlin)
-        DependencyInjector.injectDependencies(viewModel)
+        DependencyInjector.injectDependencies(viewModel, owner = viewModel)
         return viewModel
     }
 }

--- a/di/src/main/java/com/zzang/di/annotation/lifecycle/ActivityComponent.kt
+++ b/di/src/main/java/com/zzang/di/annotation/lifecycle/ActivityComponent.kt
@@ -1,0 +1,5 @@
+package com.zzang.di.annotation.lifecycle
+
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class ActivityComponent

--- a/di/src/main/java/com/zzang/di/annotation/lifecycle/ApplicationComponent.kt
+++ b/di/src/main/java/com/zzang/di/annotation/lifecycle/ApplicationComponent.kt
@@ -1,0 +1,5 @@
+package com.zzang.di.annotation.lifecycle
+
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class ApplicationComponent

--- a/di/src/main/java/com/zzang/di/annotation/lifecycle/ViewModelComponent.kt
+++ b/di/src/main/java/com/zzang/di/annotation/lifecycle/ViewModelComponent.kt
@@ -1,0 +1,5 @@
+package com.zzang.di.annotation.lifecycle
+
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class ViewModelComponent

--- a/di/src/main/java/com/zzang/di/base/DIActivity.kt
+++ b/di/src/main/java/com/zzang/di/base/DIActivity.kt
@@ -1,0 +1,22 @@
+package com.zzang.di.base
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import com.zzang.di.DIContainer
+import com.zzang.di.DependencyInjector
+
+abstract class DIActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        injectDependencies()
+    }
+
+    protected open fun injectDependencies() {
+        DependencyInjector.injectDependencies(this, this)
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        DIContainer.clearActivityScopedInstances(this)
+    }
+}

--- a/di/src/main/java/com/zzang/di/base/DIViewModel.kt
+++ b/di/src/main/java/com/zzang/di/base/DIViewModel.kt
@@ -1,0 +1,20 @@
+package com.zzang.di.base
+
+import androidx.lifecycle.ViewModel
+import com.zzang.di.DIContainer
+import com.zzang.di.DependencyInjector
+
+abstract class DIViewModel : ViewModel() {
+    init {
+        injectDependencies()
+    }
+
+    protected open fun injectDependencies() {
+        DependencyInjector.injectDependencies(this, this)
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        DIContainer.clearViewModelScopedInstances(this)
+    }
+}

--- a/di/src/test/java/com/zzang/di/ActivityLifeCycleTest.kt
+++ b/di/src/test/java/com/zzang/di/ActivityLifeCycleTest.kt
@@ -71,7 +71,7 @@ class ActivityLifeCycleTest {
         assertThat(activity.fakeService).isSameInstanceAs(originalFakeService)
     }
 
-    //onPause
+    // onPause
     @Test
     fun `Activity가 onPause될 때 fakeService가 유지된다`() {
         // GIVEN
@@ -85,7 +85,7 @@ class ActivityLifeCycleTest {
         assertThat(activity.fakeService).isSameInstanceAs(originalFakeService)
     }
 
-    //onRestart
+    // onRestart
     @Test
     fun `Activity가 onRestart될 때 fakeService가 유지된다`() {
         // GIVEN
@@ -112,4 +112,3 @@ class ActivityLifeCycleTest {
         assertThat(activity.fakeService).isSameInstanceAs(originalFakeService)
     }
 }
-

--- a/di/src/test/java/com/zzang/di/ActivityLifeCycleTest.kt
+++ b/di/src/test/java/com/zzang/di/ActivityLifeCycleTest.kt
@@ -1,0 +1,115 @@
+package com.zzang.di
+
+import com.google.common.truth.Truth.assertThat
+import com.zzang.di.testfixture.FakeActivity
+import com.zzang.di.testfixture.FakeApplication
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.android.controller.ActivityController
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(application = FakeApplication::class)
+class ActivityLifeCycleTest {
+    private lateinit var controller: ActivityController<FakeActivity>
+    private lateinit var activity: FakeActivity
+
+    @Before
+    fun setUp() {
+        DIContainer.clearAll()
+        controller = Robolectric.buildActivity(FakeActivity::class.java)
+        activity = controller.get()
+    }
+
+    @Test
+    fun `Activity가 onCreate될 때 fakeService가 주입된다`() {
+        // WHEN
+        controller.create()
+
+        // THEN
+        assertThat(activity.fakeService).isNotNull()
+    }
+
+    @Test
+    fun `Activity가 onDestroy될 때 fakeService가 제거된다`() {
+        // GIVEN
+        controller.create()
+
+        // WHEN
+        controller.destroy()
+
+        // THEN
+        assertThat(DIContainer.activityScopedInstanceSize()).isEqualTo(0)
+    }
+
+    @Test
+    fun `Activity가 onStart될 때 fakeService가 유지된다`() {
+        // GIVEN
+        controller.create()
+        val originalFakeService = activity.fakeService
+
+        // WHEN
+        controller.start()
+
+        // THEN
+        assertThat(activity.fakeService).isSameInstanceAs(originalFakeService)
+    }
+
+    @Test
+    fun `Activity가 onResume될 때 fakeService가 유지된다`() {
+        // GIVEN
+        controller.create()
+        val originalFakeService = activity.fakeService
+
+        // WHEN
+        controller.resume()
+
+        // THEN
+        assertThat(activity.fakeService).isSameInstanceAs(originalFakeService)
+    }
+
+    //onPause
+    @Test
+    fun `Activity가 onPause될 때 fakeService가 유지된다`() {
+        // GIVEN
+        controller.create()
+        val originalFakeService = activity.fakeService
+
+        // WHEN
+        controller.pause()
+
+        // THEN
+        assertThat(activity.fakeService).isSameInstanceAs(originalFakeService)
+    }
+
+    //onRestart
+    @Test
+    fun `Activity가 onRestart될 때 fakeService가 유지된다`() {
+        // GIVEN
+        controller.create()
+        val originalFakeService = activity.fakeService
+
+        // WHEN
+        controller.restart()
+
+        // THEN
+        assertThat(activity.fakeService).isSameInstanceAs(originalFakeService)
+    }
+
+    @Test
+    fun `Activity가 onStop될 때 fakeService가 유지된다`() {
+        // GIVEN
+        controller.create()
+        val originalFakeService = activity.fakeService
+
+        // WHEN
+        controller.stop()
+
+        // THEN
+        assertThat(activity.fakeService).isSameInstanceAs(originalFakeService)
+    }
+}
+

--- a/di/src/test/java/com/zzang/di/DIContainerTest.kt
+++ b/di/src/test/java/com/zzang/di/DIContainerTest.kt
@@ -8,7 +8,7 @@ class DIContainerTest {
     @Test
     fun `싱글톤 객체 테스트(객체 1번 생성)`() {
         // given
-        DIContainer.registerInstance(TestClass::class, TestClass())
+        DIContainer.registerSingletonInstance(TestClass::class, TestClass())
 
         // when
         val testClass1 = DIContainer.resolve(TestClass::class)

--- a/di/src/test/java/com/zzang/di/DIContainerTest.kt
+++ b/di/src/test/java/com/zzang/di/DIContainerTest.kt
@@ -8,7 +8,7 @@ class DIContainerTest {
     @Test
     fun `싱글톤 객체 테스트(객체 1번 생성)`() {
         // given
-        DIContainer.registerSingletonInstance(TestClass::class, TestClass())
+        DIContainer.registerModuleInstance(TestClass::class, TestClass())
 
         // when
         val testClass1 = DIContainer.resolve(TestClass::class)

--- a/di/src/test/java/com/zzang/di/QualifierTest.kt
+++ b/di/src/test/java/com/zzang/di/QualifierTest.kt
@@ -11,8 +11,8 @@ class QualifierTest {
     @Test
     fun `Qualifier가 InMemory일때 FakeInMemoryRepository 인스턴스를 가져온다`() {
         // given
-        DIContainer.registerInstance(TestRepository::class, FakeInMemoryRepository(), QualifierType.IN_MEMORY)
-        DIContainer.registerInstance(TestRepository::class, FakeDatabaseRepository(), QualifierType.DATABASE)
+        DIContainer.registerSingletonInstance(TestRepository::class, FakeInMemoryRepository(), QualifierType.IN_MEMORY)
+        DIContainer.registerSingletonInstance(TestRepository::class, FakeDatabaseRepository(), QualifierType.DATABASE)
 
         // when
         val inMemoryRepo = DIContainer.resolve(TestRepository::class, QualifierType.IN_MEMORY)
@@ -24,8 +24,8 @@ class QualifierTest {
     @Test
     fun `Qualifier가 Database일때 FakeDatabaseRepository 인스턴스를 가져온다`() {
         // given
-        DIContainer.registerInstance(TestRepository::class, FakeInMemoryRepository(), QualifierType.IN_MEMORY)
-        DIContainer.registerInstance(TestRepository::class, FakeDatabaseRepository(), QualifierType.DATABASE)
+        DIContainer.registerSingletonInstance(TestRepository::class, FakeInMemoryRepository(), QualifierType.IN_MEMORY)
+        DIContainer.registerSingletonInstance(TestRepository::class, FakeDatabaseRepository(), QualifierType.DATABASE)
 
         // when
         val dbRepo = DIContainer.resolve(TestRepository::class, QualifierType.DATABASE)
@@ -37,8 +37,8 @@ class QualifierTest {
     @Test
     fun `Qualifier가 없을 경우 기본값인 Database의 FakeDatabaseRepository 인스턴스를 가져온다`() {
         // given
-        DIContainer.registerInstance(TestRepository::class, FakeInMemoryRepository(), QualifierType.IN_MEMORY)
-        DIContainer.registerInstance(TestRepository::class, FakeDatabaseRepository(), QualifierType.DATABASE)
+        DIContainer.registerSingletonInstance(TestRepository::class, FakeInMemoryRepository(), QualifierType.IN_MEMORY)
+        DIContainer.registerSingletonInstance(TestRepository::class, FakeDatabaseRepository(), QualifierType.DATABASE)
 
         // when
         val dbRepo = DIContainer.resolve(TestRepository::class)

--- a/di/src/test/java/com/zzang/di/QualifierTest.kt
+++ b/di/src/test/java/com/zzang/di/QualifierTest.kt
@@ -11,8 +11,8 @@ class QualifierTest {
     @Test
     fun `Qualifier가 InMemory일때 FakeInMemoryRepository 인스턴스를 가져온다`() {
         // given
-        DIContainer.registerSingletonInstance(TestRepository::class, FakeInMemoryRepository(), QualifierType.IN_MEMORY)
-        DIContainer.registerSingletonInstance(TestRepository::class, FakeDatabaseRepository(), QualifierType.DATABASE)
+        DIContainer.registerModuleInstance(TestRepository::class, FakeInMemoryRepository(), QualifierType.IN_MEMORY)
+        DIContainer.registerModuleInstance(TestRepository::class, FakeDatabaseRepository(), QualifierType.DATABASE)
 
         // when
         val inMemoryRepo = DIContainer.resolve(TestRepository::class, QualifierType.IN_MEMORY)
@@ -24,24 +24,11 @@ class QualifierTest {
     @Test
     fun `Qualifier가 Database일때 FakeDatabaseRepository 인스턴스를 가져온다`() {
         // given
-        DIContainer.registerSingletonInstance(TestRepository::class, FakeInMemoryRepository(), QualifierType.IN_MEMORY)
-        DIContainer.registerSingletonInstance(TestRepository::class, FakeDatabaseRepository(), QualifierType.DATABASE)
+        DIContainer.registerModuleInstance(TestRepository::class, FakeInMemoryRepository(), QualifierType.IN_MEMORY)
+        DIContainer.registerModuleInstance(TestRepository::class, FakeDatabaseRepository(), QualifierType.DATABASE)
 
         // when
         val dbRepo = DIContainer.resolve(TestRepository::class, QualifierType.DATABASE)
-
-        // then
-        assertThat(dbRepo).isInstanceOf(FakeDatabaseRepository::class.java)
-    }
-
-    @Test
-    fun `Qualifier가 없을 경우 기본값인 Database의 FakeDatabaseRepository 인스턴스를 가져온다`() {
-        // given
-        DIContainer.registerSingletonInstance(TestRepository::class, FakeInMemoryRepository(), QualifierType.IN_MEMORY)
-        DIContainer.registerSingletonInstance(TestRepository::class, FakeDatabaseRepository(), QualifierType.DATABASE)
-
-        // when
-        val dbRepo = DIContainer.resolve(TestRepository::class)
 
         // then
         assertThat(dbRepo).isInstanceOf(FakeDatabaseRepository::class.java)

--- a/di/src/test/java/com/zzang/di/ViewModelLifeCycleTest.kt
+++ b/di/src/test/java/com/zzang/di/ViewModelLifeCycleTest.kt
@@ -26,7 +26,11 @@ class ViewModelLifeCycleTest {
     @Test
     fun `ViewModel을 자동으로 주입해준다`() {
         // GIVEN
-        val activity = Robolectric.buildActivity(FakeActivity::class.java).create().get()
+        val activity =
+            Robolectric
+                .buildActivity(FakeActivity::class.java)
+                .create()
+                .get()
 
         // WHEN
 
@@ -38,7 +42,11 @@ class ViewModelLifeCycleTest {
     @Test
     fun `ViewModel이 생성될 때 필요한 인스턴스가 자동으로 추가된다`() {
         // GIVEN
-        val activity = Robolectric.buildActivity(FakeActivity::class.java).create().get()
+        val activity =
+            Robolectric
+                .buildActivity(FakeActivity::class.java)
+                .create()
+                .get()
 
         // WHEN
         val viewModel = activity.viewModel
@@ -50,7 +58,11 @@ class ViewModelLifeCycleTest {
     @Test
     fun `ViewModel이 생성될 때 필요한 인스턴스가 qualifier에 따라 다르게 주입된다`() {
         // GIVEN
-        val activity = Robolectric.buildActivity(FakeActivity::class.java).create().get()
+        val activity =
+            Robolectric
+                .buildActivity(FakeActivity::class.java)
+                .create()
+                .get()
 
         // WHEN
         val viewModel = activity.viewModel
@@ -62,7 +74,11 @@ class ViewModelLifeCycleTest {
     @Test
     fun `ViewModel이 onDestroy될 때 ViewModelScope에 있는 인스턴스들이 제거된다`() {
         // GIVEN
-        val activity = Robolectric.buildActivity(FakeActivity::class.java).create().get()
+        val activity =
+            Robolectric
+                .buildActivity(FakeActivity::class.java)
+                .create()
+                .get()
         val viewModel = activity.viewModel
 
         // WHEN

--- a/di/src/test/java/com/zzang/di/ViewModelLifeCycleTest.kt
+++ b/di/src/test/java/com/zzang/di/ViewModelLifeCycleTest.kt
@@ -4,7 +4,7 @@ import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import com.google.common.truth.Truth.assertThat
 import com.zzang.di.testfixture.FakeActivity
 import com.zzang.di.testfixture.FakeApplication
-import com.zzang.di.testfixture.FakeViewModel
+import org.junit.After
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -18,14 +18,57 @@ class ViewModelLifeCycleTest {
     @get:Rule
     var instantTaskExecutorRule = InstantTaskExecutorRule()
 
+    @After
+    fun tearDown() {
+        DIContainer.clearAll()
+    }
+
     @Test
-    fun `ViewModel이 생성될 때 인스턴스가 저장된다`() {
+    fun `ViewModel을 자동으로 주입해준다`() {
         // GIVEN
-        Robolectric.buildActivity(FakeActivity::class.java).create().get()
+        val activity = Robolectric.buildActivity(FakeActivity::class.java).create().get()
 
         // WHEN
 
         // THEN
-        assertThat(DIContainer.resolve(FakeViewModel::class)).isNotNull()
+        val viewModel = activity.viewModel
+        assertThat(viewModel).isNotNull()
+    }
+
+    @Test
+    fun `ViewModel이 생성될 때 필요한 인스턴스가 자동으로 추가된다`() {
+        // GIVEN
+        val activity = Robolectric.buildActivity(FakeActivity::class.java).create().get()
+
+        // WHEN
+        val viewModel = activity.viewModel
+
+        // THEN
+        assertThat(viewModel.inMemoryRepository).isNotNull()
+    }
+
+    @Test
+    fun `ViewModel이 생성될 때 필요한 인스턴스가 qualifier에 따라 다르게 주입된다`() {
+        // GIVEN
+        val activity = Robolectric.buildActivity(FakeActivity::class.java).create().get()
+
+        // WHEN
+        val viewModel = activity.viewModel
+
+        // THEN
+        assertThat(viewModel.inMemoryRepository).isNotSameInstanceAs(viewModel.databaseRepository)
+    }
+
+    @Test
+    fun `ViewModel이 onDestroy될 때 ViewModelScope에 있는 인스턴스들이 제거된다`() {
+        // GIVEN
+        val activity = Robolectric.buildActivity(FakeActivity::class.java).create().get()
+        val viewModel = activity.viewModel
+
+        // WHEN
+        viewModel.onCleared()
+
+        // THEN
+        assertThat(DIContainer.viewModelScopedInstanceSize()).isEqualTo(0)
     }
 }

--- a/di/src/test/java/com/zzang/di/ViewModelLifeCycleTest.kt
+++ b/di/src/test/java/com/zzang/di/ViewModelLifeCycleTest.kt
@@ -1,0 +1,31 @@
+package com.zzang.di
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import com.google.common.truth.Truth.assertThat
+import com.zzang.di.testfixture.FakeActivity
+import com.zzang.di.testfixture.FakeApplication
+import com.zzang.di.testfixture.FakeViewModel
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(application = FakeApplication::class)
+class ViewModelLifeCycleTest {
+    @get:Rule
+    var instantTaskExecutorRule = InstantTaskExecutorRule()
+
+    @Test
+    fun `ViewModel이 생성될 때 인스턴스가 저장된다`() {
+        // GIVEN
+        Robolectric.buildActivity(FakeActivity::class.java).create().get()
+
+        // WHEN
+
+        // THEN
+        assertThat(DIContainer.resolve(FakeViewModel::class)).isNotNull()
+    }
+}

--- a/di/src/test/java/com/zzang/di/testfixture/FakeActivity.kt
+++ b/di/src/test/java/com/zzang/di/testfixture/FakeActivity.kt
@@ -1,0 +1,22 @@
+package com.zzang.di.testfixture
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import com.zzang.di.DIContainer
+import com.zzang.di.DependencyInjector
+import com.zzang.di.annotation.Inject
+
+class FakeActivity : ComponentActivity() {
+    @Inject
+    lateinit var fakeService: FakeService
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        DependencyInjector.injectDependencies(this,this)
+        fakeService.doSomething()
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        DIContainer.clearActivityScopedInstances(this)
+    }
+}

--- a/di/src/test/java/com/zzang/di/testfixture/FakeActivity.kt
+++ b/di/src/test/java/com/zzang/di/testfixture/FakeActivity.kt
@@ -5,13 +5,15 @@ import androidx.activity.ComponentActivity
 import com.zzang.di.DIContainer
 import com.zzang.di.DependencyInjector
 import com.zzang.di.annotation.Inject
+import com.zzang.di.provideViewModel
 
 class FakeActivity : ComponentActivity() {
     @Inject
     lateinit var fakeService: FakeService
+    val viewModel: FakeViewModel by provideViewModel()
 
     override fun onCreate(savedInstanceState: Bundle?) {
-        DependencyInjector.injectDependencies(this,this)
+        DependencyInjector.injectDependencies(this, this)
         fakeService.doSomething()
     }
 

--- a/di/src/test/java/com/zzang/di/testfixture/FakeApplication.kt
+++ b/di/src/test/java/com/zzang/di/testfixture/FakeApplication.kt
@@ -1,0 +1,11 @@
+package com.zzang.di.testfixture
+
+import android.app.Application
+import com.zzang.di.DIContainer
+
+class FakeApplication : Application() {
+    override fun onCreate() {
+        super.onCreate()
+        DIContainer.loadModule(FakeModule())
+    }
+}

--- a/di/src/test/java/com/zzang/di/testfixture/FakeModule.kt
+++ b/di/src/test/java/com/zzang/di/testfixture/FakeModule.kt
@@ -1,0 +1,21 @@
+package com.zzang.di.testfixture
+
+import com.zzang.di.DIContainer
+import com.zzang.di.annotation.QualifierType
+import com.zzang.di.module.DIModule
+
+class FakeModule : DIModule {
+    override fun register(container: DIContainer) {
+        container.registerModuleInstance(
+            type = TestRepository::class,
+            instance = FakeDatabaseRepository(),
+            qualifier = QualifierType.DATABASE,
+        )
+
+        container.registerModuleInstance(
+            type = TestRepository::class,
+            instance = FakeInMemoryRepository(),
+            qualifier = QualifierType.IN_MEMORY,
+        )
+    }
+}

--- a/di/src/test/java/com/zzang/di/testfixture/FakeService.kt
+++ b/di/src/test/java/com/zzang/di/testfixture/FakeService.kt
@@ -1,0 +1,10 @@
+package com.zzang.di.testfixture
+
+import com.zzang.di.annotation.lifecycle.ActivityComponent
+
+@ActivityComponent
+class FakeService {
+    fun doSomething() {
+        println("do something")
+    }
+}

--- a/di/src/test/java/com/zzang/di/testfixture/FakeViewModel.kt
+++ b/di/src/test/java/com/zzang/di/testfixture/FakeViewModel.kt
@@ -1,0 +1,13 @@
+package com.zzang.di.testfixture
+
+import com.zzang.di.annotation.Inject
+import com.zzang.di.annotation.QualifierType
+import com.zzang.di.base.DIViewModel
+
+class FakeViewModel : DIViewModel() {
+    @Inject(qualifier = QualifierType.IN_MEMORY)
+    lateinit var fakeInMemoryRepository: TestRepository
+
+    @Inject(qualifier = QualifierType.DATABASE)
+    lateinit var fakeDatabaseRepository: TestRepository
+}

--- a/di/src/test/java/com/zzang/di/testfixture/FakeViewModel.kt
+++ b/di/src/test/java/com/zzang/di/testfixture/FakeViewModel.kt
@@ -2,12 +2,24 @@ package com.zzang.di.testfixture
 
 import androidx.lifecycle.ViewModel
 import com.zzang.di.DIContainer
+import com.zzang.di.DependencyInjector
 import com.zzang.di.annotation.Inject
 import com.zzang.di.annotation.QualifierType
 
 class FakeViewModel : ViewModel() {
     @Inject(qualifier = QualifierType.IN_MEMORY)
-    lateinit var fakeInMemoryRepository: TestRepository
+    lateinit var inMemoryRepository: TestRepository
+
+    @Inject(qualifier = QualifierType.DATABASE)
+    lateinit var databaseRepository: TestRepository
+
+    init {
+        injectDependencies()
+    }
+
+    private fun injectDependencies() {
+        DependencyInjector.injectDependencies(this, this)
+    }
 
     public override fun onCleared() {
         super.onCleared()

--- a/di/src/test/java/com/zzang/di/testfixture/FakeViewModel.kt
+++ b/di/src/test/java/com/zzang/di/testfixture/FakeViewModel.kt
@@ -1,13 +1,16 @@
 package com.zzang.di.testfixture
 
+import androidx.lifecycle.ViewModel
+import com.zzang.di.DIContainer
 import com.zzang.di.annotation.Inject
 import com.zzang.di.annotation.QualifierType
-import com.zzang.di.base.DIViewModel
 
-class FakeViewModel : DIViewModel() {
+class FakeViewModel : ViewModel() {
     @Inject(qualifier = QualifierType.IN_MEMORY)
     lateinit var fakeInMemoryRepository: TestRepository
 
-    @Inject(qualifier = QualifierType.DATABASE)
-    lateinit var fakeDatabaseRepository: TestRepository
+    public override fun onCleared() {
+        super.onCleared()
+        DIContainer.clearViewModelScopedInstances(this)
+    }
 }

--- a/di/src/test/java/com/zzang/di/testfixture/TestRepository.kt
+++ b/di/src/test/java/com/zzang/di/testfixture/TestRepository.kt
@@ -1,5 +1,8 @@
 package com.zzang.di.testfixture
 
+import com.zzang.di.annotation.lifecycle.ViewModelComponent
+
+@ViewModelComponent
 interface TestRepository {
     suspend fun test()
 }


### PR DESCRIPTION
안녕하세요 채드~~~~~ 👋🏻
step4 미션으로 다시 인사드려요! 


---

## 4단계: LifeCycle

### 기능 요구 사항 🛠️

- [x] CartActivity에서 사용하는 DateFormatter의 인스턴스를 매번 개발자가 관리해야 하는 문제를 해결한다.
- [x] 모든 의존성이 싱글 오브젝트로 만들어질 필요 없다.
    - [x] CartRepository는 앱 전체 LifeCycle 동안 유지되도록 구현한다.
    - [x] ProductRepository는 ViewModel LifeCycle 동안 유지되도록 구현한다.
    - [x] DateFormatter는 Activity LifeCycle 동안 유지되도록 구현한다.
- [x] 내가 만든 DI 라이브러리가 잘 작동하는지 테스트를 작성한다.

### 선택 요구 사항 📦

- [ ] DateFormatter가 Configuration Changes에도 살아남을 수 있도록 구현한다.
- [ ] Activity, ViewModel 외에도 다양한 컴포넌트(Fragment, Service 등)별 유지될 의존성을 관리한다.

--- 

### 내가 만든 것은 라이브러리인가? 프레임워크인가?
제어의 주도권이 누구에게 있냐라고 생각한다면, 제가 만든 di는 라이브러리에 가깝다고 생각합니다. 작동 중에 기능이 필요할 때만 능동적으로 사용하기 때문입니다.

### 내가 만든 것은 서비스 로케이터인가? DI인가?
DI를 만들고자 했지만, 결국 서비스 로케이터에 더 가깝다고 생각합니다.
서비스 로케이터는 객체가 필요한 시점에 의존성을 직접 조회하는 반면, DI(의존성 주입)는 외부에서 의존성을 주입해줍니다.
저의 라이브러리는 서비스 로케이터와 같이 의존성을 자신이 필요한 시점에 직접 조회하는 방식으로 만들어졌기 때문입니다.
그리고 코틀린 reflection을 사용했기 때문에 런타임 오류를 발생시키고 있습니다.

### 내가 만든 것은 자동 DI인가? 수동 DI인가?
자동 DI를 구현했지만, reflection을 사용하여 런타임에 의존성을 주입하다 보니 컴파일 타임에 오류를 잡기 어렵고, 런타임 오류가 발생할 수 있다는 한계가 있습니다.

### 안드로이드 애플리케이션의 구조적 한계
runtime시점에서는 완벽하게 만들기 힘들다는 구조적인 한계가 존재합니다.
안드로이드 컴포넌트(Activity, Fragment)의 복잡한 생명주기 관리와 런타임 의존성 주입의 특성 때문에, 의존성 관리가 어려워지고 런타임 오류를 피하기 힘들다는 구조적인 한계가 존재합니다.

### 그런데 사용자에게 맡기는 게 자연스러운 걸까?
자연스럽지 않다고 생각합니다. DI의 핵심은 의존성을 사용자에게 직접 관리하지 않도록 하는 것입니다. 
의존성을 주입하는 책임을 라이브러리가 대신 가지고 관리하여 개발자는 비즈니스 로직에 집중할 수 있도록 자동 DI를 통해 의존성 관리를 최대한 단순화하여 사용성을 높여야 합니다.


---

현재 테스트 코드를 작성 중인데 너무 어렵네요 🥺
이 부분은 추가 보완하겠습니다!~

제가 구현한 방식은 Module을 사용해 미리 instances를 저장해놓고, 
resolve할 때 (즉 주입이 필요해질 때) 어노테이션 기반 스코프를 등록합니다. 
주입하는 activity 또는 viewmodel (=owner) 을 기억해두고 clear 될 때 해당하는 map 들을 삭제하는 형식으로 구현을 하였습니다.