### PR TITLE
setup -> setUp 오타 수정

### DIFF
--- a/app/src/main/java/woowacourse/shopping/ui/MainActivity.kt
+++ b/app/src/main/java/woowacourse/shopping/ui/MainActivity.kt
@@ -24,10 +24,10 @@ class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        setupContentView()
-        setupBinding()
-        setupToolbar()
-        setupViewData()
+        setUpContentView()
+        setUpBinding()
+        setUpToolbar()
+        setUpViewData()
     }
 
     override fun onCreateOptionsMenu(menu: Menu?): Boolean {
@@ -38,7 +38,7 @@ class MainActivity : AppCompatActivity() {
         return true
     }
 
-    private fun setupContentView() {
+    private fun setUpContentView() {
         enableEdgeToEdge()
         setContentView(binding.root)
         ViewCompat.setOnApplyWindowInsetsListener(binding.root) { v, insets ->
@@ -48,25 +48,25 @@ class MainActivity : AppCompatActivity() {
         }
     }
 
-    private fun setupBinding() {
+    private fun setUpBinding() {
         binding.lifecycleOwner = this
         binding.vm = viewModel
     }
 
-    private fun setupToolbar() {
+    private fun setUpToolbar() {
         setSupportActionBar(binding.toolbar)
     }
 
-    private fun setupViewData() {
-        setupProductData()
-        setupProductList()
+    private fun setUpViewData() {
+        setUpProductData()
+        setUpProductList()
     }
 
-    private fun setupProductData() {
+    private fun setUpProductData() {
         viewModel.getAllProducts()
     }
 
-    private fun setupProductList() {
+    private fun setUpProductList() {
         viewModel.products.observe(this) {
             val adapter = ProductAdapter(
                 items = it,

--- a/app/src/main/java/woowacourse/shopping/ui/cart/CartActivity.kt
+++ b/app/src/main/java/woowacourse/shopping/ui/cart/CartActivity.kt
@@ -23,11 +23,11 @@ class CartActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        setupContentView()
-        setupDateFormatter()
-        setupBinding()
-        setupToolbar()
-        setupViewData()
+        setUpContentView()
+        setUpDateFormatter()
+        setUpBinding()
+        setUpToolbar()
+        setUpViewData()
     }
 
     override fun onSupportNavigateUp(): Boolean {
@@ -35,7 +35,7 @@ class CartActivity : AppCompatActivity() {
         return true
     }
 
-    private fun setupContentView() {
+    private fun setUpContentView() {
         enableEdgeToEdge()
         setContentView(binding.root)
         ViewCompat.setOnApplyWindowInsetsListener(binding.root) { v, insets ->
@@ -45,30 +45,30 @@ class CartActivity : AppCompatActivity() {
         }
     }
 
-    private fun setupDateFormatter() {
+    private fun setUpDateFormatter() {
         dateFormatter = DateFormatter(this)
     }
 
-    private fun setupToolbar() {
+    private fun setUpToolbar() {
         setSupportActionBar(binding.toolbar)
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
     }
 
-    private fun setupBinding() {
+    private fun setUpBinding() {
         binding.lifecycleOwner = this
         binding.vm = viewModel
     }
 
-    private fun setupViewData() {
-        setupCartProductData()
-        setupCartProductList()
+    private fun setUpViewData() {
+        setUpCartProductData()
+        setUpCartProductList()
     }
 
-    private fun setupCartProductData() {
+    private fun setUpCartProductData() {
         viewModel.getAllCartProducts()
     }
 
-    private fun setupCartProductList() {
+    private fun setUpCartProductList() {
         viewModel.cartProducts.observe(this) {
             val adapter = CartProductAdapter(
                 items = it,


### PR DESCRIPTION
`MainActivity`, `CartActivity`에 존재하는 `setupXXX` 형식의 함수들의 이름을 `setUpXXX` 형식으로 수정하였습니다.

`설정`을 의미하는 명사 `setup`보다 `설정하다`라는 뜻의 동사 `set up`이 더 잘 어울린다고 생각했습니다.

따라서 해당 단어에 카멜 케이스를 적용한 `setUpXXX` 형식으로 수정하였습니다.